### PR TITLE
Update README pre-commit snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In your `.pre-commit-config.yaml` file, add the following under the `repos` key:
 ```yaml
 repos:
 -   repo: https://github.com/kchason/rdf-toolkit-action
-    rev: v0.2.0
+    rev: 0.2.0
     hooks:
     -   id: rdf-toolkit-normalizer
         args:


### PR DESCRIPTION
The `v` in the version doesn't work when this snippet is copy-pasted into a config file.  This works without the `v`.